### PR TITLE
add zen5 to the list of architectures

### DIFF
--- a/scripts/process_eessi_software_metadata.py
+++ b/scripts/process_eessi_software_metadata.py
@@ -17,6 +17,7 @@ ARCHITECTURES = [
     "x86_64/amd/zen2",
     "x86_64/amd/zen3",
     "x86_64/amd/zen4",
+    "x86_64/amd/zen5",
     "x86_64/intel/haswell",
     "x86_64/intel/skylake_avx512",
     "x86_64/intel/sapphirerapids",


### PR DESCRIPTION
@ocaisa Can I just add it like this (since it's not supported by 2023.06)?